### PR TITLE
avoid sip 6.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not x86_64]
 requirements:
   build:
@@ -64,12 +64,12 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - pyqt-builder                           # [build_platform != target_platform]
-    - sip                                    # [build_platform != target_platform]
+    - sip !=6.6.2                            # [build_platform != target_platform]
     - make
   host:
     - python
     - pip
-    - sip                                    # [build_platform == target_platform]
+    - sip !=6.6.2                            # [build_platform == target_platform]
     - toml
     - pyqt-builder                           # [build_platform == target_platform]
     - packaging


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I'm having some difficulties building `qgis` over in https://github.com/conda-forge/qgis-feedstock/pull/250 and I think this is because of issues introduced in `sip =6.2`. This PR rebuilds to avoid that version of sip, which I believe will enable us to finally update `qgis`.